### PR TITLE
Feature/adressesøk

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/tps/AdresseSokController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/tps/AdresseSokController.kt
@@ -1,0 +1,45 @@
+package no.nav.sbl.sosialhjelp_mock_alt.integrations.tps
+
+
+import no.nav.sbl.sosialhjelp_mock_alt.integrations.tps.dto.AdresseData
+import no.nav.sbl.sosialhjelp_mock_alt.integrations.tps.dto.AdresseSokResponse
+import no.nav.sbl.sosialhjelp_mock_alt.objectMapper
+import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
+import org.springframework.util.MultiValueMap
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AdresseSokController {
+    companion object {
+        private val log by logger()
+    }
+
+    @GetMapping("/tps/adressesoek", produces = ["application/json;charset=UTF-8"])
+    fun adressesok(@RequestParam parameters: MultiValueMap<String, String>): String {
+        return objectMapper.writeValueAsString(defaultAdressesok())
+    }
+
+    private fun defaultAdressesok() : AdresseSokResponse {
+        return AdresseSokResponse(
+                flereTreff = false,
+                adresseDataList = listOf(
+                        AdresseData(
+                                kommunenummer = "1234",
+                                kommunenavn = "Mock Kommune",
+                                adressenavn = "Mock veien",
+                                husnummerFra = "1",
+                                husnummerTil = "42",
+                                postnummer = "0101",
+                                poststed = "Mock by",
+                                geografiskTilknytning = "1234",
+                                gatekode = "gatekode",
+                                bydel = "bydel",
+                                husnummer = "2",
+                                husbokstav = ""
+                        )
+                )
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/tps/AdresseSokController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/tps/AdresseSokController.kt
@@ -26,7 +26,7 @@ class AdresseSokController {
                 flereTreff = false,
                 adresseDataList = listOf(
                         AdresseData(
-                                kommunenummer = "1234",
+                                kommunenummer = "1000",
                                 kommunenavn = "Mock Kommune",
                                 adressenavn = "Mock veien",
                                 husnummerFra = "1",

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/tps/dto/AdresseSokResponse.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/tps/dto/AdresseSokResponse.kt
@@ -1,0 +1,22 @@
+package no.nav.sbl.sosialhjelp_mock_alt.integrations.tps.dto
+
+data class AdresseSokResponse(
+        val flereTreff: Boolean,
+        val adresseDataList: List<AdresseData>
+)
+
+data class AdresseData(
+        val kommunenummer: String?,
+        val kommunenavn: String?,
+        val adressenavn: String?,
+        val husnummerFra: String?,
+        val husnummerTil: String?,
+        val postnummer: String?,
+        val poststed: String?,
+        val geografiskTilknytning: String?,
+        val gatekode: String?,
+        val bydel: String?,
+        val husnummer: String?,
+        val husbokstav: String?,
+)
+


### PR DESCRIPTION
Legger til støtte for adressesøk-tjenesten i mock-alt. MVP som bare returnerer 1 mock-adresse