### PR TITLE
Feature/pdl soknad support

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
@@ -3,27 +3,47 @@ package no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.Adressebeskyttelse
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.Gradering
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.Kjoenn
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlBostedsadresse
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlEndring
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlFoedsel
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlFoedselsdato
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlFolkeregistermetadata
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlFolkeregisterpersonstatus
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlInnsynHentPerson
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlInnsynPerson
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlInnsynPersonResponse
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlKjoenn
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlMetadata
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlModiaHentPerson
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlModiaPerson
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlModiaPersonResponse
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlNavn
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlPersonNavn
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSivilstand
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadBarn
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadBarnResponse
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadEktefelle
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadEktefelleResponse
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadHentBarn
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadHentEktefelle
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadHentPerson
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadPerson
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadPersonNavn
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlSoknadPersonResponse
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlStatsborgerskap
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlTelefonnummer
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.PdlVegadresse
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.Personalia
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.SivilstandType
 import no.nav.sbl.sosialhjelp_mock_alt.utils.fastFnr
+import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigPersonnummer
 import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
 import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
-class PdlService() {
-    companion object {
-        val log by logger()
-    }
+class PdlService {
 
     final val personListe: HashMap<String, Personalia> = HashMap()
 
@@ -45,6 +65,9 @@ class PdlService() {
                 .locked()
         personListe.put(svenskBruker.fnr, svenskBruker)
     }
+
+    private val ektefelleMap = mutableMapOf<String, PdlSoknadEktefelle>()
+    private val barnMap = mutableMapOf<String, PdlSoknadBarn>()
 
     fun getInnsynResponseFor(ident: String): PdlInnsynPersonResponse {
         log.info("Henter PDL innsyns data for $ident")
@@ -89,6 +112,90 @@ class PdlService() {
         )
     }
 
+    fun getSoknadPersonResponseFor(ident: String): PdlSoknadPersonResponse {
+        log.info("Henter PDL soknad data for (person) $ident")
+
+        val personalia = personListe[ident]
+        var adressebeskyttelse = Adressebeskyttelse(Gradering.UGRADERT)
+        var navn = PdlSoknadPersonNavn("Person", "", "Testperson", defaultMetadata(), defaultFolkeregistermetadata())
+        var sivilstand = PdlSivilstand(SivilstandType.UGIFT, null, defaultMetadata(), defaultFolkeregistermetadata())
+        var statsborgerskap = PdlStatsborgerskap("NOR")
+        var bostedsadresse = PdlBostedsadresse(null, defaultAdresse, null, null)
+        
+        if (personalia != null) {
+            navn = PdlSoknadPersonNavn(personalia.navn.fornavn, personalia.navn.mellomnavn, personalia.navn.etternavn, defaultMetadata(), defaultFolkeregistermetadata())
+            adressebeskyttelse = Adressebeskyttelse(personalia.addressebeskyttelse)
+            if (personalia.sivilstand.equals("GIFT", true) || personalia.sivilstand.equals("PARTNER", true)) {
+                val ektefelleIdent = genererTilfeldigPersonnummer()
+                sivilstand = PdlSivilstand(SivilstandType.valueOf(personalia.sivilstand), ektefelleIdent, defaultMetadata(), defaultFolkeregistermetadata())
+                when (personalia.ektefelle) {
+                    "EKTEFELLE_SAMME_BOSTED" -> ektefelleMap[ektefelleIdent] = ektefelleSammeBosted
+                    "EKTEFELLE_ANNET_BOSTED" -> ektefelleMap[ektefelleIdent] = ektefelleAnnetBosted
+                    "EKTEFELLE_MED_ADRESSEBESKYTTELSE" -> ektefelleMap[ektefelleIdent] = ektefelleMedAdressebeskyttelse
+                }
+            }
+            statsborgerskap = PdlStatsborgerskap(personalia.starsborgerskap)
+            bostedsadresse = PdlBostedsadresse(null, PdlVegadresse("matrikkelId", personalia.bostedsadresse.adressenavn, personalia.bostedsadresse.husnummer, null, null, personalia.bostedsadresse.postnummer, personalia.bostedsadresse.kommunenummer, null), null, null)
+        }
+
+        return PdlSoknadPersonResponse(
+                errors = null,
+                data = PdlSoknadHentPerson(
+                        hentPerson = PdlSoknadPerson(
+                                adressebeskyttelse = listOf(adressebeskyttelse),
+                                bostedsadresse = listOf(bostedsadresse),
+                                kontaktadresse = emptyList(),
+                                oppholdsadresse = emptyList(),
+                                familierelasjoner = emptyList(),
+                                navn = listOf(navn),
+                                sivilstand = listOf(sivilstand),
+                                statsborgerskap = listOf(statsborgerskap)
+                        )
+                )
+        )
+    }
+
+    fun getSoknadEktefelleResponseFor(ident: String): PdlSoknadEktefelleResponse {
+        log.info("Henter PDL soknad data for (ektefelle) $ident")
+
+        val defaultEktefelle = PdlSoknadEktefelle(
+                adressebeskyttelse = listOf(Adressebeskyttelse(Gradering.UGRADERT)),
+                bostedsadresse = listOf(PdlBostedsadresse(null, defaultAdresse, null, null)),
+                foedsel = listOf(PdlFoedsel(LocalDate.of(1956, 4, 3))),
+                navn = listOf(PdlSoknadPersonNavn("Ektefelle", "", "McEktefelle", defaultMetadata(), defaultFolkeregistermetadata()))
+        )
+
+        val pdlEktefelle = ektefelleMap[ident] ?: defaultEktefelle
+
+        return PdlSoknadEktefelleResponse(
+                errors = null,
+                data = PdlSoknadHentEktefelle(
+                        hentPerson = pdlEktefelle
+                )
+        )
+    }
+
+    fun getSoknadBarnResponseFor(ident: String): PdlSoknadBarnResponse {
+        log.info("Henter PDL soknad data for (barn) $ident")
+
+        val defaultBarn = PdlSoknadBarn(
+                adressebeskyttelse = listOf(Adressebeskyttelse(Gradering.UGRADERT)),
+                bostedsadresse = listOf(PdlBostedsadresse(null, defaultAdresse, null, null)),
+                folkeregistepersonstatus = listOf(PdlFolkeregisterpersonstatus("bosatt")),
+                foedsel = listOf(PdlFoedsel(LocalDate.now().minusYears(10))),
+                navn = listOf(PdlSoknadPersonNavn("Kid", "", "McKid", defaultMetadata(), defaultFolkeregistermetadata()))
+        )
+
+        val pdlBarn = barnMap[ident] ?: defaultBarn
+
+        return PdlSoknadBarnResponse(
+                errors = null,
+                data = PdlSoknadHentBarn(
+                        hentPerson = pdlBarn
+                )
+        )
+    }
+
     fun leggTilPerson(personalia: Personalia) {
         personListe.put(personalia.fnr, personalia)
     }
@@ -100,5 +207,53 @@ class PdlService() {
     fun getPersonListe(): List<Personalia> {
         val personListe = personListe.values.sortedBy { it.opprettetTidspunkt }
         return personListe
+    }
+
+    companion object {
+        private val log by logger()
+
+        private val defaultAdresse = PdlVegadresse("matrikkelId", "gateveien", 1, "A", null, "0101", "0301", "H101")
+        private val annenAdresse = PdlVegadresse("matrikkelId2", "Karl Johans gate", 1, null, null, "0101", "0301", null)
+
+        private val ektefelleSammeBosted = PdlSoknadEktefelle(
+                adressebeskyttelse = listOf(Adressebeskyttelse(Gradering.UGRADERT)),
+                bostedsadresse = listOf(PdlBostedsadresse(null, defaultAdresse, null, null)),
+                foedsel = listOf(PdlFoedsel(LocalDate.of(1955, 5, 5))),
+                navn = listOf(PdlSoknadPersonNavn("LILLA", "", "EKTEFELLE", defaultMetadata(), defaultFolkeregistermetadata()))
+        )
+
+        private val ektefelleAnnetBosted = PdlSoknadEktefelle(
+                adressebeskyttelse = listOf(Adressebeskyttelse(Gradering.UGRADERT)),
+                bostedsadresse = listOf(PdlBostedsadresse(null, annenAdresse, null, null)),
+                foedsel = listOf(PdlFoedsel(LocalDate.of(1966,6,6))),
+                navn = listOf(PdlSoknadPersonNavn("GUL", "", "EKTEFELLE", defaultMetadata(), defaultFolkeregistermetadata()))
+        )
+
+        private val ektefelleMedAdressebeskyttelse = PdlSoknadEktefelle(
+                adressebeskyttelse = listOf(Adressebeskyttelse(Gradering.FORTROLIG)),
+                bostedsadresse = emptyList(),
+                foedsel = emptyList(),
+                navn = emptyList()
+        )
+
+        private fun defaultMetadata() =
+                PdlMetadata(
+                        "PDL",
+                        listOf(PdlEndring(
+                                kilde = "NAV",
+                                registrert = LocalDateTime.now().minusDays(7),
+                                registrertAv = "saksbehandler",
+                                systemkilde = "kilde",
+                                type = "type"
+                        ))
+                )
+
+        private fun defaultFolkeregistermetadata() =
+                PdlFolkeregistermetadata(
+                        ajourholdstidspunkt = LocalDateTime.now().minusDays(6),
+                        gyldighetstidspunkt = LocalDateTime.now().minusYears(1),
+                        opphoerstidspunkt = null,
+                        kilde = "kilde"
+                )
     }
 }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/model/Personalia.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/model/Personalia.kt
@@ -9,6 +9,7 @@ data class Personalia(
         var addressebeskyttelse: Gradering = Gradering.UGRADERT,
         var sivilstand: String = "UOPPGITT",
         var starsborgerskap: String = "NOR",
+        var bostedsadresse: ForenkletBostedsadresse = ForenkletBostedsadresse("Hovedveien", 42, "0101", "0301"),
         var locked: Boolean = false,
         var opprettetTidspunkt: Long = DateTime.now().millis
 ) {
@@ -43,4 +44,16 @@ data class Personalia(
         opprettetTidspunkt = tidspunkt
         return this
     }
+
+    fun withBostedsadresse(nyBostedsadresse: ForenkletBostedsadresse): Personalia {
+        bostedsadresse = nyBostedsadresse
+        return this
+    }
 }
+
+data class ForenkletBostedsadresse(
+        val adressenavn: String,
+        val husnummer: Int,
+        val postnummer: String,
+        val kommunenummer: String
+)

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/model/Personalia.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/model/Personalia.kt
@@ -8,6 +8,7 @@ data class Personalia(
         val navn: PdlPersonNavn = PdlPersonNavn(),
         var addressebeskyttelse: Gradering = Gradering.UGRADERT,
         var sivilstand: String = "UOPPGITT",
+        var ektefelle: String? = null,
         var starsborgerskap: String = "NOR",
         var bostedsadresse: ForenkletBostedsadresse = ForenkletBostedsadresse("Hovedveien", 42, "0101", "0301"),
         var locked: Boolean = false,
@@ -27,6 +28,11 @@ data class Personalia(
 
     fun withSivilstand(nyVerdi: String): Personalia {
         sivilstand = nyVerdi
+        return this
+    }
+
+    fun withEktefelle(nyVerdi: String): Personalia {
+        ektefelle = nyVerdi
         return this
     }
 

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/pdl/PdlController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/pdl/PdlController.kt
@@ -25,12 +25,28 @@ class PdlController(private val pdlService: PdlService) {
         return decideResponse(pdlRequest)
     }
 
+    /**
+     * familierelasjoner -> kun del av person-request fra soknad-api
+     * folkeregisterpersonstatus -> kun del av barn-request fra soknad-api
+     * bostedsadresse -> del av ektefelle-request fra soknad-api (gjelder også de 2 over, men denne inneholder verken familierelasjoner eller folkeregisterpersonstatus)
+     * adressebeskyttelse -> del av request fra innsyn-api (gjelder også de 3 over, men denne inneholder verken familierelasjoner, folkeregisterpersonstatus eller bostedsadresse)
+     * kjoenn -> kun del av request fra modia-api
+     */
     private fun decideResponse(pdlRequest: PdlRequest): String {
         return when {
+            pdlRequest.query.contains(Regex("(familierelasjoner)")) -> {
+                objectMapper.writeValueAsString(pdlService.getSoknadPersonResponseFor(pdlRequest.variables.ident))
+            }
+            pdlRequest.query.contains(Regex("(folkeregisterpersonstatus)")) -> {
+                objectMapper.writeValueAsString(pdlService.getSoknadBarnResponseFor(pdlRequest.variables.ident))
+            }
+            pdlRequest.query.contains(Regex("(bostedsadresse)")) -> {
+                objectMapper.writeValueAsString(pdlService.getSoknadEktefelleResponseFor(pdlRequest.variables.ident))
+            }
             pdlRequest.query.contains(Regex("(adressebeskyttelse)")) -> {
                 objectMapper.writeValueAsString(pdlService.getInnsynResponseFor(pdlRequest.variables.ident))
             }
-            pdlRequest.query.contains(Regex("(navn)|(kjoenn)|(telefonnummer)|(foedsel)")) -> {
+            pdlRequest.query.contains(Regex("(kjoenn)")) -> {
                 objectMapper.writeValueAsString(pdlService.getModiaResponseFor(pdlRequest.variables.ident))
             }
             else -> "OK"


### PR DESCRIPTION
Utvider personalia med bostedsadresse og ektefelle.
Mock-alt-api kan nå returnere pdl-responser til soknad-api for person, ektefelle og barn