### PR TITLE
Endrer Utbetalinger slik at det fremstår som i oppslag-api.

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
@@ -298,9 +298,9 @@ class PdlService(
                 startDato = LocalDate.now().minusYears(10),
                 orgnummmer = organisasjonsnummer,
         )
-        utbetalingService.putUtbetalingerFraNav(brukerFnr, listOf(UtbetalingDto()))
 
         skatteetatenService.enableAutoGenerationFor(brukerFnr)
+        utbetalingService.enableAutoGenerationFor(brukerFnr)
         bostotteService.enableAutoGenerationFor(brukerFnr)
 
         soknadService.opprettDigisosSak(enhetsnummer, kommuneNummer, brukerFnr, brukerFnr)

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
@@ -47,6 +47,7 @@ import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.Personalia
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.SivilstandType
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.SkatteetatenService
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.UtbetalingService
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingDto
 import no.nav.sbl.sosialhjelp_mock_alt.utils.MockAltException
 import no.nav.sbl.sosialhjelp_mock_alt.utils.fastFnr
 import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigOrganisasjonsnummer
@@ -56,9 +57,6 @@ import no.nav.sbl.sosialhjelp_mock_alt.utils.randomInt
 import no.nav.sbl.sosialhjelp_mock_alt.utils.randomLong
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import kotlin.random.Random
-import kotlin.random.nextInt
-import kotlin.random.nextLong
 
 @Service
 class PdlService(
@@ -300,9 +298,9 @@ class PdlService(
                 startDato = LocalDate.now().minusYears(10),
                 orgnummmer = organisasjonsnummer,
         )
+        utbetalingService.putUtbetalingerFraNav(brukerFnr, listOf(UtbetalingDto()))
 
         skatteetatenService.enableAutoGenerationFor(brukerFnr)
-        utbetalingService.enableAutoGenerationFor(brukerFnr)
         bostotteService.enableAutoGenerationFor(brukerFnr)
 
         soknadService.opprettDigisosSak(enhetsnummer, kommuneNummer, brukerFnr, brukerFnr)

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/UtbetalingService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/UtbetalingService.kt
@@ -1,33 +1,24 @@
 package no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling
 
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingDto
-import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingsListeDto
 import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 
 @Service
 class UtbetalingService {
+    private final val utbetalingListMap: HashMap<String, List<UtbetalingDto>> = HashMap()
 
-    final val utbetalingslisten: HashMap<String, UtbetalingsListeDto> = HashMap()
-    final val autoGenerationSet: HashSet<String> = HashSet()
-
-    fun putUtbetalingerFraNav(fnr: String, utbetaling: UtbetalingsListeDto) {
-        utbetalingslisten[fnr] = utbetaling
+    fun getUtbetalingerFraNav(ident: String): List<UtbetalingDto> {
+        log.info("Henter utbetalinger for $ident")
+        return utbetalingListMap[ident] ?: emptyList()
     }
 
-    fun getUtbetalingerFraNav(fnr: String): UtbetalingsListeDto {
-        if (autoGenerationSet.contains(fnr)) {
-            return UtbetalingsListeDto().add(UtbetalingDto(12000.0, LocalDate.now().minusDays(14)))
-        }
-        return utbetalingslisten[fnr] ?: UtbetalingsListeDto()
-    }
-
-    fun enableAutoGenerationFor(fnr: String) {
-        autoGenerationSet.add(fnr)
+    fun putUtbetalingerFraNav(ident: String, utbetalinger: List<UtbetalingDto>) {
+        utbetalingListMap[ident] = utbetalinger
     }
 
     companion object {
         private val log by logger()
     }
+
 }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/UtbetalingService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/UtbetalingService.kt
@@ -3,18 +3,27 @@ package no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingDto
 import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class UtbetalingService {
     private final val utbetalingListMap: HashMap<String, List<UtbetalingDto>> = HashMap()
+    private final val autoGenerationSet: HashSet<String> = HashSet()
 
     fun getUtbetalingerFraNav(ident: String): List<UtbetalingDto> {
         log.info("Henter utbetalinger for $ident")
-        return utbetalingListMap[ident] ?: emptyList()
+        if (autoGenerationSet.contains(ident)) {
+            return listOf(UtbetalingDto(netto = 12000.0, utbetalingsdato = LocalDate.now().minusDays(14)))
+        }
+        return utbetalingListMap[ident] ?: listOf(UtbetalingDto())
     }
 
     fun putUtbetalingerFraNav(ident: String, utbetalinger: List<UtbetalingDto>) {
         utbetalingListMap[ident] = utbetalinger
+    }
+
+    fun enableAutoGenerationFor(fnr: String) {
+        autoGenerationSet.add(fnr)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/model/Utbetaling.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/model/Utbetaling.kt
@@ -1,24 +1,27 @@
 package no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model
 
+import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigOrganisasjonsnummer
 import java.time.LocalDate
 
-data class UtbetalingsListeDto(
-        var utbetalinger: List<UtbetalingDto> = listOf(),
-) {
-    fun add(utbetalingDto: UtbetalingDto): UtbetalingsListeDto {
-        val mutableList = mutableListOf<UtbetalingDto>()
-        mutableList.addAll(utbetalinger)
-        mutableList.add(utbetalingDto)
-        utbetalinger = mutableList
-        return this
-    }
-}
-
 data class UtbetalingDto(
-        val belop: Double = 1337.0,
-        val dato: LocalDate = LocalDate.now(),
-        val ytelsestype: String = "Dagpenger",
-        val melding: String = "",
-        val skattebelop: Double = 0.0,
-        val ytelseskomponenttype: String = "",
+    val type: String = "navytelse",
+    val netto: Double = 1337.0,
+    val brutto: Double = 2000.0,
+    val skattetrekk: Double = 600.0,
+    val andreTrekk: Double = 63.0,
+    val bilagsnummer: String? = "bilagsnummer",
+    val utbetalingsdato: LocalDate? = LocalDate.now(),
+    val periodeFom: LocalDate? = LocalDate.now().minusDays(14),
+    val periodeTom: LocalDate? = LocalDate.now().minusDays(2),
+    val komponenter: List<KomponentDto> = listOf(KomponentDto()),
+    val tittel: String = "Dagpenger",
+    val orgnummer: String = genererTilfeldigOrganisasjonsnummer()
+)
+
+data class KomponentDto(
+    val type: String? = "type",
+    val belop: Double = 42.0,
+    val satstype: String? = "satstype",
+    val satsbelop: Double = 21.0,
+    val satsantall: Double = 2.0
 )

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/utbetaling/UtbetalingController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/utbetaling/UtbetalingController.kt
@@ -2,30 +2,34 @@ package no.nav.sbl.sosialhjelp_mock_alt.integrations.utbetaling
 
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.feil.FeilService
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.UtbetalingService
-import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingsListeDto
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingDto
 import no.nav.sbl.sosialhjelp_mock_alt.objectMapper
+import no.nav.sbl.sosialhjelp_mock_alt.utils.hentFnrFraToken
 import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class UtbetalingController(
-        private val utbetalingService: UtbetalingService,
-        private val feilService: FeilService,
+    private val utbetalingService: UtbetalingService,
+    private val feilService: FeilService,
 ) {
-    companion object {
-        private val log by logger()
-    }
 
-    @GetMapping("/utbetaling")
-    fun getStatteetatenInntekt(
-            @RequestParam fnr: String,
-): ResponseEntity<UtbetalingsListeDto> {
-        feilService.eventueltLagFeil(fnr, "UtbetalingController", "getStatteetatenInntekt")
-        val utbetalinger = utbetalingService.getUtbetalingerFraNav(fnr)
+    @GetMapping("/oppslag-api/utbetalinger")
+    fun getUtbetalingerFraNav(
+        @RequestHeader headers: HttpHeaders
+    ): ResponseEntity<List<UtbetalingDto>> {
+        val ident = hentFnrFraToken(headers)
+        feilService.eventueltLagFeil(ident, "UtbetalingController", "getUtbetalingerFraNav")
+        val utbetalinger = utbetalingService.getUtbetalingerFraNav(ident)
         log.info("Henter utbetalinger fra nav: ${objectMapper.writeValueAsString(utbetalinger)}")
         return ResponseEntity.ok(utbetalinger)
+    }
+
+    companion object {
+        private val log by logger()
     }
 }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/frontend/FrontendController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/frontend/FrontendController.kt
@@ -13,7 +13,6 @@ import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.model.Personalia
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.SkatteetatenService
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.model.SkattbarInntekt
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.UtbetalingService
-import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingsListeDto
 import no.nav.sbl.sosialhjelp_mock_alt.objectMapper
 import no.nav.sbl.sosialhjelp_mock_alt.otherEndpoints.frontend.model.FrontendArbeidsforhold
 import no.nav.sbl.sosialhjelp_mock_alt.otherEndpoints.frontend.model.FrontendBarn.Companion.frontendBarn
@@ -87,8 +86,11 @@ class FrontendController(
         personalia.bostotteSaker.forEach { bostotteDto.saker.add(it) }
         personalia.bostotteUtbetalinger.forEach { bostotteDto.utbetalinger.add(it) }
         bostotteService.putBostotte(personalia.fnr, bostotteDto)
-        utbetalingService.putUtbetalingerFraNav(personalia.fnr,
-                UtbetalingsListeDto(personalia.utbetalingerFraNav.map { it.frontToBackend() }))
+        utbetalingService.putUtbetalingerFraNav(
+            ident = personalia.fnr,
+            utbetalinger = personalia.utbetalingerFraNav.map { it.toUtbetalingDto() }
+        )
+
         return ResponseEntity.ok("OK")
     }
 
@@ -117,7 +119,7 @@ class FrontendController(
         frontendPersonalia.bostotteSaker = bostotteDto.saker
         frontendPersonalia.bostotteUtbetalinger = bostotteDto.utbetalinger
         frontendPersonalia.utbetalingerFraNav =
-                utbetalingService.getUtbetalingerFraNav(personalia.fnr).utbetalinger.map { mapToFrontend(it) }
+            utbetalingService.getUtbetalingerFraNav(personalia.fnr).map { mapToFrontend(it) }
 
         return ResponseEntity.ok(frontendPersonalia)
     }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/frontend/model/FrontendPersonalia.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/frontend/model/FrontendPersonalia.kt
@@ -24,6 +24,7 @@ import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.model.Forskuddstre
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.model.Inntekt
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.model.Inntektstype
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.model.OppgaveInntektsmottaker
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.KomponentDto
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model.UtbetalingDto
 import no.nav.sbl.sosialhjelp_mock_alt.utils.MockAltException
 import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigPersonnummer
@@ -205,19 +206,26 @@ data class FrontendUtbetalingFraNav(
         val skattebelop: Double,
         val ytelseskomponenttype: String,
 ) {
-    fun frontToBackend(): UtbetalingDto {
-        return UtbetalingDto(belop, dato, ytelsestype, melding, skattebelop, ytelseskomponenttype)
+
+    fun toUtbetalingDto(): UtbetalingDto {
+        return UtbetalingDto(
+            tittel = ytelsestype,
+            netto = belop,
+            skattetrekk = skattebelop,
+            utbetalingsdato = dato,
+            komponenter = listOf(KomponentDto(type = ytelseskomponenttype))
+        )
     }
 
     companion object {
         fun mapToFrontend(utbetaling: UtbetalingDto): FrontendUtbetalingFraNav {
             return FrontendUtbetalingFraNav(
-                    utbetaling.belop,
-                    utbetaling.dato,
-                    utbetaling.ytelsestype,
-                    utbetaling.melding,
-                    utbetaling.skattebelop,
-                    utbetaling.ytelseskomponenttype,
+                utbetaling.netto,
+                utbetaling.utbetalingsdato ?: LocalDate.now(),
+                utbetaling.tittel,
+                "", // melding?
+                utbetaling.skattetrekk,
+                utbetaling.komponenter.first().type ?: ""
             )
         }
     }


### PR DESCRIPTION
Holder frontend-representasjonen uforandret - mapper bare til ny dto.