### PR TITLE
Bruk samme geografisktilknytning som i tps adresseservice

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlAdresseSokService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlAdresseSokService.kt
@@ -22,7 +22,7 @@ class PdlAdresseSokService {
     fun putAdresse(
         postnummer: String,
         adresse: ForenkletBostedsadresse,
-        geografiskTilknytning: String? = "030102"
+        geografiskTilknytning: String? = "0315"
     ) {
         adresseMap[postnummer] = PdlAdresseSokResponse(
             errors = null,


### PR DESCRIPTION
tror dette skapte følgefeil til NorgUtil.lagMockNavEnhet
->`NumberFormatException: For input string: "030102030102"`, som vel er større enn Int.MAX_VALUE