### PR TITLE
korrigerer criteria etter endring i PDL sokAdresse (og soknad-api)

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/pdl/PdlService.kt
@@ -49,11 +49,11 @@ import no.nav.sbl.sosialhjelp_mock_alt.datastore.skatteetaten.SkatteetatenServic
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.UtbetalingService
 import no.nav.sbl.sosialhjelp_mock_alt.utils.MockAltException
 import no.nav.sbl.sosialhjelp_mock_alt.utils.fastFnr
+import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigKontonummer
 import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigOrganisasjonsnummer
 import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigPersonnummer
 import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
 import no.nav.sbl.sosialhjelp_mock_alt.utils.randomInt
-import no.nav.sbl.sosialhjelp_mock_alt.utils.randomLong
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -297,7 +297,7 @@ class PdlService(
         adresseService.putAdresseInfo(standardBruker.bostedsadresse.postnummer, standardBruker.bostedsadresse, enhetsnummer)
         pdlAdresseSokService.putAdresse(standardBruker.bostedsadresse.postnummer, standardBruker.bostedsadresse, enhetsnummer)
         dkifService.putDigitalKontaktinfo(brukerFnr, DigitalKontaktinfo(mobiltelefonnummer = randomInt(8).toString()))
-        kontonummerService.putKontonummer(brukerFnr, randomLong(11).toString())
+        kontonummerService.putKontonummer(brukerFnr, genererTilfeldigKontonummer())
         val organisasjonsnummer = genererTilfeldigOrganisasjonsnummer()
         eregService.putOrganisasjonNoekkelinfo(organisasjonsnummer, "Arbeidsgiveren AS")
         aaregService.leggTilEnkeltArbeidsforhold(

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/pdl/PdlController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/pdl/PdlController.kt
@@ -91,7 +91,7 @@ class PdlController(
     }
 
     private fun handleSokAdresseRequest(sokAdresseRequest: SokAdresseRequest, ident: String): String {
-        val postnummer = sokAdresseRequest.variables.criteria.first { it.fieldName == "postnummer" }.searchRule["equals"] ?: ""
+        val postnummer = sokAdresseRequest.variables.criteria.first { it.fieldName == "vegadresse.postnummer" }.searchRule["equals"] ?: ""
         feilService.eventueltLagFeil(ident, "PdlController", "getSokAdresse")
         return objectMapper.writeValueAsString(pdlAdresseSokService.getAdresse(postnummer))
     }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/utils/Utils.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/utils/Utils.kt
@@ -16,7 +16,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.pow
 import kotlin.math.roundToInt
-import kotlin.math.roundToLong
+import kotlin.random.Random.Default.nextLong
 import kotlin.reflect.full.companionObject
 
 val fastFnr = genererTilfeldigPersonnummer(dato = LocalDate.of(1945, 10, 26), Kjoenn.KVINNE)
@@ -90,8 +90,10 @@ fun randomInt(length: Int): Int {
     return (Math.random() * 10.0.pow(length.toDouble())).roundToInt()
 }
 
-fun randomLong(length: Int): Long {
-    return (Math.random() * 10.0.pow(length.toDouble())).roundToLong()
+fun genererTilfeldigKontonummer(): String {
+    val min = 10_000_000_000L
+    val max = 99_999_999_999L
+    return nextLong(min, max).toString()
 }
 
 fun <R : Any> R.logger(): Lazy<Logger> {


### PR DESCRIPTION
Fikser også generering av tilfeldige kontonumre, som tidligere kunne bli færre enn 11 tegn (og derfor ikke validere i filformat)