### PR TITLE
host som queryparam for docker-compose

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/wellknown/WellKnownController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/wellknown/WellKnownController.kt
@@ -32,7 +32,7 @@ class WellKnownController(
         val baseUrl = host?.let { hostAddress(it) } ?: hostAddress
         val wellknown = WellKnown(
             issuer = mockOAuth2Server.issuerUrl(issuer).toString(),
-            tokenEndpoint = "$baseUrl}sosialhjelp/mock-alt-api/token/$issuer",
+            tokenEndpoint = "${baseUrl}sosialhjelp/mock-alt-api/token/$issuer",
             jwksURI = "${baseUrl}sosialhjelp/mock-alt-api/jwks/$issuer"
         )
         log.info("Metadata for issuer=$issuer: \n$wellknown")


### PR DESCRIPTION
hvis well-known  GET request inneholder `host` som queryParam, endrer vi host for token- og jwks-endpoint

Dette for at ting skal kunne fungere for både kjøring av soknad-api/innsyn-api lokalt i IntelliJ eller via docker-compose (via docker-compose spesifiserer vi `?host=<abc>` i well-known-urler)