### PR TITLE
loginapi-controller: endre host basert på env-variabler

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,6 @@ springdoc:
 
 mock-oauth2-server:
   port: 4321
+
+innsyn-api-via-docker-compose: ${INNSYN_API_VIA_DOCKER_COMPOSE:false}
+soknad-api-via-docker-compose: ${SOKNAD_API_VIA_DOCKER_COMPOSE:false}


### PR DESCRIPTION
 env-variabler som sier om soknad-api og innsyn-api kjører lokalt eller i docker-compose