### PR TITLE
Gjør det mulig å sende søknader til SvarUt kommune for å trigge gammel ettersendelse

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/fiks/KommuneInfoService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/fiks/KommuneInfoService.kt
@@ -21,6 +21,24 @@ class KommuneInfoService {
         kommuneInfoMap[kommunenummer] = lagKommuneInfo(kommunenummer)
     }
 
+    fun addSvarutKommuneInfo(kommunenummer: String) {
+        kommuneInfoMap[kommunenummer] = lagSvarUtKommune(kommunenummer)
+    }
+
+    private fun lagSvarUtKommune(id: String) = KommuneInfo(
+        kommunenummer = id,
+        kanMottaSoknader = false,
+        kanOppdatereStatus = false,
+        harMidlertidigDeaktivertOppdateringer = false,
+        harMidlertidigDeaktivertMottak = false,
+        kontaktpersoner = Kontaktpersoner(
+            Collections.singletonList("Kontakt$id@navo.no"),
+            Collections.singletonList("Test$id@navno.no")
+        ),
+        harNksTilgang = false,
+        behandlingsansvarlig = null
+    )
+
     private fun lagKommuneInfo(id: String) = KommuneInfo(
         kommunenummer = id,
         kanMottaSoknader = true,

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/norg/NorgService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/norg/NorgService.kt
@@ -15,6 +15,7 @@ class NorgService {
         val aarstad = lagMockNavEnhet("1208", "NAV Årstad, Årstad kommune")
         val bergenhus = lagMockNavEnhet("1209", "NAV Bergenhus, Bergen kommune")
         val ytrebygda = lagMockNavEnhet("1210", "NAV Ytrebygda, Bergen kommune")
+        val horten = lagMockNavEnhet("0701", "NAV Horten")
 
         navEnheter[sentrum.enhetNr] = sentrum
         navEnheter[grunerokka.enhetNr] = grunerokka
@@ -24,6 +25,7 @@ class NorgService {
 
         gtNavEnheter["0301"] = sentrum
         gtNavEnheter["4601"] = bergenhus
+        gtNavEnheter["0701"] = horten
     }
 
     fun getNavenhet(enhetsnr: String): NavEnhet? {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/kodeverk/KodeverkController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/kodeverk/KodeverkController.kt
@@ -22,6 +22,7 @@ class KodeverkController(
         landkoder = lesKodeverk("landkoder")
         postnummer = lesKodeverk("postnummer")
         kommuner.betydninger.keys.forEach { kommuneInfoService.addKommunieInfo(it) }
+        kommuneInfoService.addSvarutKommuneInfo("0701")
     }
 
     private fun lesKodeverk(navn: String): KodeverkDto {

--- a/src/main/resources/adressesok/sanner_adressesok.json
+++ b/src/main/resources/adressesok/sanner_adressesok.json
@@ -7,6 +7,19 @@
           "vegadresse": {
             "matrikkelId": "abcd1",
             "husnummer": 1,
+            "husbokstav": "A",
+            "adressenavn": "Svarutgata",
+            "postnummer": "9999",
+            "poststed": "SVARUT",
+            "kommunenavn": "SVARUT",
+            "kommunenummer": "0701"
+          }
+        },
+        {
+          "score": 2,
+          "vegadresse": {
+            "matrikkelId": "abcd1",
+            "husnummer": 1,
             "husbokstav": "B",
             "adressenavn": "Sannergata",
             "postnummer": "0557",


### PR DESCRIPTION
Ved å søke etter "Svarutgata" i adressesøk kan vi nå trigge levering til SvarUt og få gammel ettersendelse i søknad med mock-alt.