### PR TITLE
Legger til støtte for ereg url slik den ble i fss-proxy

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/ereg/EregController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/ereg/EregController.kt
@@ -28,4 +28,15 @@ class EregController(private val eregService: EregService) {
         log.info("Henter ereg nøkkelinfo: ${objectMapper.writeValueAsString(nokkelinfo)}")
         return ResponseEntity.ok(nokkelinfo)
     }
+
+    @GetMapping("/ereg/organisasjon/{orgnr}")
+    fun getNokkelinfoProxy(@PathVariable orgnr: String, @RequestHeader headers: HttpHeaders):
+        ResponseEntity<OrganisasjonNoekkelinfoDto> {
+        val nokkelinfo = eregService.getOrganisasjonNoekkelinfo(orgnr) ?: OrganisasjonNoekkelinfoDto(
+            navn = NavnDto("Mock navn"),
+            organisasjonsnummer = orgnr,
+        )
+        log.info("Henter ereg nøkkelinfo: ${objectMapper.writeValueAsString(nokkelinfo)}")
+        return ResponseEntity.ok(nokkelinfo)
+    }
 }


### PR DESCRIPTION
Støtter begge url-varianter inntil soknad-api benytter seg utelukkende av fss-proxy varianten