### PR TITLE
støtter at søknad går over til å ikke kalle kodeverk via fss-proxy

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/kodeverk/KodeverkController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/kodeverk/KodeverkController.kt
@@ -34,6 +34,21 @@ class KodeverkController(
         private val log by logger()
     }
 
+    @GetMapping("/kodeverk/{kodeverknavn}/koder/betydninger")
+    fun hentKodeverk(@PathVariable kodeverknavn: String): ResponseEntity<KodeverkDto> {
+        log.debug("Kodeverk request: $kodeverknavn")
+        if (kodeverknavn == "Kommuner") {
+            return ResponseEntity.ok(kommuner)
+        }
+        if (kodeverknavn == "Landkoder") {
+            return ResponseEntity.ok(landkoder)
+        }
+        if (kodeverknavn == "Postnummer") {
+            return ResponseEntity.ok(postnummer)
+        }
+        return ResponseEntity.notFound().build()
+    }
+
     @GetMapping("/kodeverk/{kodeverknavn}")
     fun hentKodeverkProxy(@PathVariable kodeverknavn: String): ResponseEntity<KodeverkDto> {
         log.debug("Kodeverk request: $kodeverknavn")


### PR DESCRIPTION
siden kodeverk har ingresser som kan nås direkte fra SBS og GCP.

Sees sammen med https://github.com/navikt/sosialhjelp-soknad-api/pull/1376