### PR TITLE
Legger til et dummy endepunkt på `soknad-api/soknadoversikt/soknader`…

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SaksListeDto.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SaksListeDto.kt
@@ -1,0 +1,13 @@
+package no.nav.sbl.sosialhjelp_mock_alt.otherEndpoints.soknadApi
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.util.Date
+
+data class SaksListeDto(
+    val fiksDigisosId: String?,
+    val soknadTittel: String,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    val sistOppdatert: Date,
+    val kilde: String,
+    val url: String?
+)

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -23,7 +23,7 @@ class SoknadApiController(
 
     @GetMapping("soknad-api/dialog/sistInnsendteSoknad")
     @ResponseBody
-    fun soknadStatus(@RequestHeader headers: HttpHeaders): ResponseEntity<SoknadStatus> {
+    fun soknadStatus(@RequestHeader headers: HttpHeaders): ResponseEntity<SoknadStatusDto> {
         val ident = hentFnrFraToken(headers)
         log.info("Henter soknadsstatus for brukerId $ident")
         return try {
@@ -31,12 +31,19 @@ class SoknadApiController(
             val status = if (personalia.navn.mellomnavn == "IngenSoknader") {
                 null
             } else {
-                SoknadStatus(ident, "Hamar kommune", LocalDateTime.now())
+                SoknadStatusDto(ident, "Hamar kommune", LocalDateTime.now())
             }
             ResponseEntity.ok(status)
         } catch (e: MockAltException) {
             log.info("Feil ved henting av brukers soknadsstatus: ${e.message}")
             ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         }
+    }
+
+    @GetMapping("soknad-api/soknadoversikt/soknader")
+    @ResponseBody
+    fun soknadoversikt(@RequestHeader headers: HttpHeaders): ResponseEntity<List<SaksListeDto>> {
+        // dummy endepunkt som returnerer 200 OK med en tom liste.
+        return ResponseEntity.ok(emptyList())
     }
 }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadStatusDto.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadStatusDto.kt
@@ -2,7 +2,7 @@ package no.nav.sbl.sosialhjelp_mock_alt.otherEndpoints.soknadApi
 
 import java.time.LocalDateTime
 
-class SoknadStatus(
+class SoknadStatusDto(
     val ident: String,
     val navEnhet: String,
     val innsendtDato: LocalDateTime


### PR DESCRIPTION
… som returnerer tom liste.

Hvorfor? Slik at innsyn-api ikke trenger at soknad-api kjører lokalt ved lokal utvikling