### PR TITLE
legger til mocking av svarut-integrasjon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,5 @@ Interne henvendelser kan sendes via Slack i kanalen #team_digisos.
 ### Krav
 - JDK 17
 
-## Teknisk info
-
-### Ktlint
-Hvordan kjøre Ktlint:
-* Fra IDEA: Kjør Gradle Task: sosialhjelp-mock-alt-api -> Tasks -> formatting -> ktlintFormat
-* Fra terminal:
-    * Kun formater: `./gradlew ktlintFormat`
-    * Formater og bygg: `./gradlew ktlintFormat build`
-    * Hvis IntelliJ begynner å hikke, kan en kjøre `./gradlew clean ktlintFormat build`
-
-Endre IntelliJ autoformateringskonfigurasjon for dette prosjektet:
-* `./gradlew ktlintApplyToIdea`
-
-Legg til pre-commit check/format hooks:
-* `./gradlew addKtlintCheckGitPreCommitHook`
-* `./gradlew addKtlintFormatGitPreCommitHook`
+## Hvordan komme i gang
+### [Felles dokumentasjon for våre backend apper](https://teamdigisos.intern.nav.no/docs/utviklerdokumentasjon/kom%20igang%20med%20utvikling#backend-gradle)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ val junitVersion = "4.13.2"
 val log4jVersion = "2.17.2"
 val snakeyamlVersion = "1.31"
 val ktlint = "0.45.2"
+val svarUtVersion = "1.1.0"
 
 plugins {
     kotlin("jvm") version "1.7.10"
@@ -76,6 +77,9 @@ dependencies {
     implementation("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
 
     implementation("org.springdoc:springdoc-openapi-ui:$springdocversion")
+
+    // SvarUt
+    implementation("no.ks.fiks.svarut:svarut-rest-klient:$svarUtVersion")
 
     testImplementation("no.nav.security:token-validation-spring-test:$tokenValidationVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/fiks/SvarUtService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/fiks/SvarUtService.kt
@@ -1,0 +1,38 @@
+package no.nav.sbl.sosialhjelp_mock_alt.datastore.fiks
+
+import no.ks.fiks.svarut.klient.model.Forsendelse
+import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
+import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class SvarUtService(
+    @Value("\${filter_soknader_on_fnr}") private val filterSoknaderOnFnr: Boolean,
+) {
+    private val forsendelseSoknadMap: HashMap<String, Pair<Forsendelse, JsonSoknad>> = HashMap()
+
+    fun addSvarUtSoknad(fnr: String, forsendelse: Forsendelse, jsonSoknad: JsonSoknad) {
+        forsendelseSoknadMap[fnr] = forsendelse to jsonSoknad
+    }
+
+    fun getSvarUtSoknader(fnr: String?): MutableCollection<Pair<Forsendelse, JsonSoknad>> {
+        if (fnr == null) {
+            log.info("Henter søknadsliste. Antall SvarUt-soknader: ${forsendelseSoknadMap.size}")
+            return forsendelseSoknadMap.values
+        }
+        if (filterSoknaderOnFnr) {
+            return forsendelseSoknadMap.values
+                .filter { it.second.data.personalia.personIdentifikator.verdi == fnr }
+                .toMutableList()
+                .also { log.info("Henter søknadsliste. Antall SvarUt-soknader for $fnr: ${it.size}") }
+        }
+
+        log.info("- returnerer fortsatt alle. Antall SvarUt-soknader: ${forsendelseSoknadMap.size}")
+        return forsendelseSoknadMap.values
+    }
+
+    companion object {
+        val log by logger()
+    }
+}

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/fiks/SvarUtController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/integrations/fiks/SvarUtController.kt
@@ -1,0 +1,43 @@
+package no.nav.sbl.sosialhjelp_mock_alt.integrations.fiks
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.ks.fiks.svarut.klient.model.Forsendelse
+import no.ks.fiks.svarut.klient.model.ForsendelsesId
+import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.fiks.SvarUtService
+import no.nav.sbl.sosialhjelp_mock_alt.objectMapper
+import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.multipart.support.StandardMultipartHttpServletRequest
+import java.util.UUID
+
+@RestController
+class SvarUtController(
+    private val svarUtService: SvarUtService
+) {
+    companion object {
+        private val log by logger()
+    }
+
+    @PostMapping("/svarut/tjenester/api/forsendelse/v1/sendForsendelse")
+    fun sendSoknad(
+        request: StandardMultipartHttpServletRequest
+    ): ResponseEntity<ForsendelsesId> {
+
+        val multiFileMap = request.multiFileMap["filer"]!!
+        val jsonSoknadPart: MultipartFile = multiFileMap.first { it.originalFilename == "soknad.json" }
+        val jsonSoknad = objectMapper.readValue(jsonSoknadPart.inputStream, JsonSoknad::class.java)
+        val fnr = jsonSoknad.data.personalia.personIdentifikator.verdi
+
+        val forsendelseString = request.getParameter("forsendelse")
+        val forsendelse = objectMapper.readValue<Forsendelse>(forsendelseString)
+
+        svarUtService.addSvarUtSoknad(fnr, forsendelse, jsonSoknad)
+        log.info("SvarUt-soknad med soknadId ${forsendelse.eksternReferanse.removePrefix("-")} har blitt lastet opp")
+
+        return ResponseEntity.ok(ForsendelsesId(UUID.randomUUID()))
+    }
+}

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -48,7 +48,7 @@ class SoknadApiController(
     }
 
     /**
-     * Endepunktet kalles kun ved av innsyn-api ved lokal kjøring
+     * Endepunktet kalles kun av innsyn-api ved lokal kjøring
      */
     @GetMapping("soknad-api/soknadoversikt/soknader")
     @ResponseBody

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -59,7 +59,7 @@ class SoknadApiController(
                     soknadTittel = "Økonomisk sosialhjelp ($soknadId)",
                     sistOppdatert = Date.from(LocalDateTime.parse(it.second.innsendingstidspunkt, DateTimeFormatter.ISO_DATE_TIME).toInstant(ZoneOffset.UTC)),
                     kilde = "soknad-api",
-                    url = "$soknadFrontendBaseUrl/sosialhjelp/soknad/skjema/$soknadId/ettersendelse"
+                    url = "$soknadFrontendBaseUrl/skjema/$soknadId/ettersendelse"
                 )
             }
         return ResponseEntity.ok(list)

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -54,7 +54,7 @@ class SoknadApiController(
     @ResponseBody
     fun soknadoversikt(@RequestHeader headers: HttpHeaders): ResponseEntity<List<SaksListeDto>> {
         val ident = hentFnrFraToken(headers)
-        val list = svarUtService.getSvarUtSoknader(ident)
+        val svarUtSoknader = svarUtService.getSvarUtSoknader(ident)
             .map {
                 val soknadId = it.first.eksternReferanse.removePrefix("-")
                 SaksListeDto(
@@ -65,6 +65,6 @@ class SoknadApiController(
                     url = "$soknadFrontendBaseUrl/skjema/$soknadId/ettersendelse"
                 )
             }
-        return ResponseEntity.ok(list)
+        return ResponseEntity.ok(svarUtSoknader)
     }
 }

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -17,7 +17,6 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Date
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 class SoknadApiController(
@@ -50,7 +49,7 @@ class SoknadApiController(
 
     @GetMapping("soknad-api/soknadoversikt/soknader")
     @ResponseBody
-    fun soknadoversikt(@RequestHeader headers: HttpHeaders, request: HttpServletRequest): ResponseEntity<List<SaksListeDto>> {
+    fun soknadoversikt(@RequestHeader headers: HttpHeaders): ResponseEntity<List<SaksListeDto>> {
         val ident = hentFnrFraToken(headers)
         val list = svarUtService.getSvarUtSoknader(ident)
             .map {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -47,6 +47,9 @@ class SoknadApiController(
         }
     }
 
+    /**
+     * Endepunktet kalles kun ved av innsyn-api ved lokal kjøring
+     */
     @GetMapping("soknad-api/soknadoversikt/soknader")
     @ResponseBody
     fun soknadoversikt(@RequestHeader headers: HttpHeaders): ResponseEntity<List<SaksListeDto>> {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/soknadApi/SoknadApiController.kt
@@ -1,9 +1,11 @@
 package no.nav.sbl.sosialhjelp_mock_alt.otherEndpoints.soknadApi
 
+import no.nav.sbl.sosialhjelp_mock_alt.datastore.fiks.SvarUtService
 import no.nav.sbl.sosialhjelp_mock_alt.datastore.pdl.PdlService
 import no.nav.sbl.sosialhjelp_mock_alt.utils.MockAltException
 import no.nav.sbl.sosialhjelp_mock_alt.utils.hentFnrFraToken
 import no.nav.sbl.sosialhjelp_mock_alt.utils.logger
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -12,10 +14,16 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Date
+import javax.servlet.http.HttpServletRequest
 
 @RestController
 class SoknadApiController(
     private val pdlService: PdlService,
+    private val svarUtService: SvarUtService,
+    @Value("\${soknad-frontend-baseurl}") private val soknadFrontendBaseUrl: String
 ) {
     companion object {
         private val log by logger()
@@ -42,8 +50,19 @@ class SoknadApiController(
 
     @GetMapping("soknad-api/soknadoversikt/soknader")
     @ResponseBody
-    fun soknadoversikt(@RequestHeader headers: HttpHeaders): ResponseEntity<List<SaksListeDto>> {
-        // dummy endepunkt som returnerer 200 OK med en tom liste.
-        return ResponseEntity.ok(emptyList())
+    fun soknadoversikt(@RequestHeader headers: HttpHeaders, request: HttpServletRequest): ResponseEntity<List<SaksListeDto>> {
+        val ident = hentFnrFraToken(headers)
+        val list = svarUtService.getSvarUtSoknader(ident)
+            .map {
+                val soknadId = it.first.eksternReferanse.removePrefix("-")
+                SaksListeDto(
+                    fiksDigisosId = null,
+                    soknadTittel = "Økonomisk sosialhjelp ($soknadId)",
+                    sistOppdatert = Date.from(LocalDateTime.parse(it.second.innsendingstidspunkt, DateTimeFormatter.ISO_DATE_TIME).toInstant(ZoneOffset.UTC)),
+                    kilde = "soknad-api",
+                    url = "$soknadFrontendBaseUrl/sosialhjelp/soknad/skjema/$soknadId/ettersendelse"
+                )
+            }
+        return ResponseEntity.ok(list)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,4 +33,5 @@ soknad-api-via-docker-compose: ${SOKNAD_API_VIA_DOCKER_COMPOSE:false}
 innsyn-api-via-docker-compose: ${INNSYN_API_VIA_DOCKER_COMPOSE:false}
 modia-api-via-docker-compose: ${MODIA_API_VIA_DOCKER_COMPOSE:false}
 
-soknad-frontend-baseurl: ${HOST_ADDRESS:http://localhost:3000}
+# sett SOKNAD_FRONTEND_BASEURL som env variabel hvis lenke til ettersendelse-side skal bli korrekt ved lokal kjøring, eks: http://localhost:3000/sosialhjelp/soknad
+soknad-frontend-baseurl: ${SOKNAD_FRONTEND_BASEURL:https://digisos.ekstern.dev.nav.no/sosialhjelp/soknad}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,5 @@ mock-oauth2-server:
 soknad-api-via-docker-compose: ${SOKNAD_API_VIA_DOCKER_COMPOSE:false}
 innsyn-api-via-docker-compose: ${INNSYN_API_VIA_DOCKER_COMPOSE:false}
 modia-api-via-docker-compose: ${MODIA_API_VIA_DOCKER_COMPOSE:false}
+
+soknad-frontend-baseurl: ${HOST_ADDRESS:http://localhost:3000}


### PR DESCRIPTION
/soknadoversikt/soknader endepunkt returnerer nå info om svarut-søknader, slik at man også kan se disse ved lokal kjøring.

i dev-gcp går innsyn-api direkte mot soknad-api for å hente informasjonen