### PR TITLE
Forenkler datamodell for utbetaldata i mock

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/model/UtbetalData.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/model/UtbetalData.kt
@@ -22,8 +22,16 @@ data class Ytelse(
 )
 
 data class Aktoer(
+    val aktoertype: Aktoertype = Aktoertype.PERSON,
+    val ident: String = "aktoerident",
     val navn: String? = "aktoernavn",
 )
+
+enum class Aktoertype {
+    PERSON,
+    ORGANISASJON,
+    SAMHANDLER,
+}
 
 data class Ytelseskomponent(
     val ytelseskomponenttype: String? = "Ytelseskomponenttype",

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/model/UtbetalData.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/datastore/utbetaling/model/UtbetalData.kt
@@ -1,77 +1,39 @@
 package no.nav.sbl.sosialhjelp_mock_alt.datastore.utbetaling.model
 
-import no.nav.sbl.sosialhjelp_mock_alt.utils.genererTilfeldigOrganisasjonsnummer
 import java.math.BigDecimal
 import java.time.LocalDate
 
 data class UtbetalDataDto(
     val utbetaltTil: Aktoer? = Aktoer(),
-    val utbetalingsmetode: String? = "metode",
-    val utbetalingsstatus: String? = "status",
-    val posteringsdato: LocalDate? = LocalDate.now().minusDays(2),
-    val forfallsdato: LocalDate? = LocalDate.now().minusDays(3),
     val utbetalingsdato: LocalDate? = LocalDate.now().minusDays(2),
-    val utbetalingNettobeloep: BigDecimal? = BigDecimal("1500.00"),
-    val utbetalingsmelding: String? = "melding",
-    val utbetaltTilKonto: Bankkonto? = Bankkonto(),
     val ytelseListe: List<Ytelse>? = listOf(Ytelse()),
 )
 
 data class Ytelse(
     val ytelsestype: String? = "Barnetrygd",
     val ytelsesperiode: Periode? = Periode(),
-    val ytelseNettobeloep: BigDecimal? = BigDecimal("1500.00"),
+    val ytelseNettobeloep: BigDecimal? = BigDecimal(1500.00),
     val rettighetshaver: Aktoer? = Aktoer(),
-    val skattsum: BigDecimal? = BigDecimal("500.00"),
-    val trekksum: BigDecimal? = BigDecimal("0"),
-    val ytelseskomponentersum: BigDecimal? = BigDecimal("2000"),
-    val skattListe: List<Skatt>? = listOf(Skatt()),
-    val trekkListe: List<Trekk>? = listOf(Trekk()),
+    val skattsum: BigDecimal? = BigDecimal(500.00),
+    val trekksum: BigDecimal? = BigDecimal.ZERO,
+    val ytelseskomponentersum: BigDecimal? = BigDecimal.ZERO,
     val ytelseskomponentListe: List<Ytelseskomponent>? = listOf(Ytelseskomponent()),
     val bilagsnummer: String? = "bilagsnummer",
-    val refundertForOrg: Aktoer? = Aktoer(
-        Aktoertype.ORGANISASJON,
-        genererTilfeldigOrganisasjonsnummer(),
-        "refundert organisasjon"
-    ),
 )
 
 data class Aktoer(
-    val aktoertype: Aktoertype = Aktoertype.PERSON,
-    val ident: String = "aktoerident",
     val navn: String? = "aktoernavn",
 )
 
 data class Ytelseskomponent(
     val ytelseskomponenttype: String? = "Ytelseskomponenttype",
-    val satsbeloep: BigDecimal? = BigDecimal("1500"),
+    val satsbeloep: BigDecimal? = BigDecimal.ZERO,
     val satstype: String? = "satstype",
     val satsantall: Double? = 2.0,
-    val ytelseskomponentbeloep: BigDecimal? = BigDecimal("2000"),
-)
-
-data class Skatt(
-    val skattebeloep: BigDecimal? = BigDecimal("500")
-)
-
-data class Trekk(
-    val trekktype: String? = "Trekktype",
-    val trekkbeloep: BigDecimal? = BigDecimal("0"),
-    val kreditor: String? = "Kreditor",
-)
-
-data class Bankkonto(
-    val kontonummer: String? = "1234567811",
-    val kontotype: String? = "kontotype",
+    val ytelseskomponentbeloep: BigDecimal? = BigDecimal.ZERO,
 )
 
 data class Periode(
     val fom: LocalDate = LocalDate.now().minusDays(25),
     val tom: LocalDate = LocalDate.now().minusDays(5),
 )
-
-enum class Aktoertype {
-    PERSON,
-    ORGANISASJON,
-    SAMHANDLER,
-}

--- a/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/frontend/model/FrontendPersonalia.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelp_mock_alt/otherEndpoints/frontend/model/FrontendPersonalia.kt
@@ -232,17 +232,19 @@ data class FrontendUtbetalingFraNav(
 
     fun toUtbetalDataDto(): UtbetalDataDto {
         return UtbetalDataDto(
-            posteringsdato = dato,
+            utbetalingsdato = dato,
             ytelseListe = listOf(
                 Ytelse(
                     ytelsestype = ytelsestype,
+                    ytelseNettobeloep = BigDecimal(belop),
                     skattsum = BigDecimal(skattebelop),
-                    ytelseskomponentListe = listOf(Ytelseskomponent(ytelseskomponenttype = ytelseskomponenttype))
+                    ytelseskomponentListe = listOf(
+                        Ytelseskomponent(
+                            ytelseskomponenttype = ytelseskomponenttype
+                        )
+                    )
                 )
             ),
-            utbetalingNettobeloep = BigDecimal(belop),
-            utbetalingsdato = dato,
-            utbetalingsmelding = melding,
         )
     }
 
@@ -256,7 +258,7 @@ data class FrontendUtbetalingFraNav(
                             belop = it.ytelseNettobeloep?.toDouble() ?: 0.00,
                             dato = utbetalingFraNav.utbetalingsdato ?: LocalDate.now(),
                             ytelsestype = it.ytelsestype ?: "",
-                            melding = utbetalingFraNav.utbetalingsmelding ?: "",
+                            melding = "",
                             skattebelop = it.skattsum?.toDouble() ?: 0.00,
                             ytelseskomponenttype = it.ytelseskomponentListe?.first()?.ytelseskomponenttype ?: ""
                         )


### PR DESCRIPTION
Rydder i ikke-påkrevde felter, som ikke trenger å være med her i mock.
Korrigerer også beløpene, slik at riktige beløp for sum og skatt vises i søknad (fremfor 1500 og 500 som var hardkoda)

![image](https://user-images.githubusercontent.com/41987225/217011394-d64461d0-2911-40e3-9e94-695f4debe483.png)

